### PR TITLE
fix: android release build bug

### DIFF
--- a/gtm/CHANGELOG.md
+++ b/gtm/CHANGELOG.md
@@ -26,3 +26,7 @@
 ## 0.0.7
 
 * apply ios static_framework
+
+## 0.0.8
+
+* fix release mode android CustomTag bug

--- a/gtm/pubspec.yaml
+++ b/gtm/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Tag Manager, A solution that allows you t
   advertising performance measurement, and affiliate marketing tracking.
 repository: https://github.com/Heewookji/gtm
 issue_tracker: https://github.com/Heewookji/gtm/issues
-version: 0.0.7
+version: 0.0.8
 
 environment:
   sdk: '>=2.18.4 <3.0.0'
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   gtm_platform_interface: ^0.0.6
-  gtm_android: ^0.0.6
+  gtm_android: ^0.0.7
   gtm_ios: ^0.0.5
 
 dev_dependencies:

--- a/gtm_android/CHANGELOG.md
+++ b/gtm_android/CHANGELOG.md
@@ -22,3 +22,7 @@
 ## 0.0.6
 
 * fix parameter nullable
+
+## 0.0.7
+
+* add @Keep to CustomTag class

--- a/gtm_android/android/src/main/kotlin/kr/heewook/gtm_android/GtmAndroidPlugin.kt
+++ b/gtm_android/android/src/main/kotlin/kr/heewook/gtm_android/GtmAndroidPlugin.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.os.Bundle
 import android.util.Log
 import androidx.annotation.NonNull
+import androidx.annotation.Keep
 import com.google.android.gms.tagmanager.CustomTagProvider
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.ktx.analytics
@@ -86,7 +87,7 @@ class GtmAndroidPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   }
 
 }
-
+@Keep
 class CustomTag: CustomTagProvider {
   @Throws(Exception::class)
   private fun encodeArguments(argumentsMap: Map<String, Any>): String {

--- a/gtm_android/pubspec.yaml
+++ b/gtm_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: gtm_android
 description: Flutter gtm plugin android
 repository: https://github.com/Heewookji/gtm
 issue_tracker: https://github.com/Heewookji/gtm/issues
-version: 0.0.6
+version: 0.0.7
 
 environment:
   sdk: '>=2.18.4 <3.0.0'


### PR DESCRIPTION
This fixes Android issue with CustomTag not working in release mode.
Since the CustomTag class is used by the gtm container and not by code, the compiler may think that the code is not used.
So it removed the CustomTag class for android minification.
[@keep](https://developer.android.com/reference/kotlin/androidx/annotation/Keep) annotation prevents this issue.
