### PR TITLE
Fix: crash on android background

### DIFF
--- a/gtm_android/android/src/main/kotlin/kr/heewook/gtm_android/GtmAndroidPlugin.kt
+++ b/gtm_android/android/src/main/kotlin/kr/heewook/gtm_android/GtmAndroidPlugin.kt
@@ -48,6 +48,9 @@ class GtmAndroidPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   override fun onDetachedFromActivity() {}
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+     if (!::channel.isInitialized) {
+        return // Prevent crash if channel is not initialized
+    }
     channel.setMethodCallHandler(null)
   }
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: MethodChannelResult) {


### PR DESCRIPTION
Closes #19 
**Problem Summary**

The plugin is crashing because of a required variable (channel) in the kr.heewook.gtm_android.GtmAndroidPlugin class has not been initialized before it's being used. This happens when the onDetachedFromEngine method of this plugin is called, which occurs when the Flutter engine is being destroyed. This suggests the plugin is attempting to use the channel during shutdown when it has already been deallocated or was never properly set up. The most likely cause is that the channel variable in GtmAndroidPlugin is not being initialized correctly or at the appropriate time. 

**Current Solution**
Check if the channel is initialized before and use the null check to exit early
```
override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
    if (!::channel.isInitialized) {
        return // Prevent crash if channel is not initialized
    }

    channel.setMethodCallHandler(null)
    // ... other cleanup
}
```
This will prevent the crash and handle the situation where detachment occurs before proper attachment.