### PR TITLE
feat: automatically resolve the native iOS gtm library to the latest compatible version

### DIFF
--- a/gtm_ios/CHANGELOG.md
+++ b/gtm_ios/CHANGELOG.md
@@ -26,3 +26,7 @@
 ## 0.1.1
 
 * apply main thread to customTag
+
+## 0.1.2
+
+* change podspec to auto resolve newest compatible gtm native library

--- a/gtm_ios/ios/gtm_ios.podspec
+++ b/gtm_ios/ios/gtm_ios.podspec
@@ -16,7 +16,7 @@ A new Flutter plugin project.
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '9.0'
-  s.dependency 'GoogleTagManager', '~> 7.4'
+  s.dependency 'GoogleTagManager', '>= 7.4'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/gtm_ios/pubspec.yaml
+++ b/gtm_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: gtm_ios
 description: Flutter gtm plugin ios
 repository: https://github.com/Heewookji/gtm
 issue_tracker: https://github.com/Heewookji/gtm/issues
-version: 0.1.1
+version: 0.1.2
 
 environment:
   sdk: '>=2.18.4 <3.0.0'


### PR DESCRIPTION
change the podspec to automatically resolve the native iOS gtm library to the latest compatible version.

This change enable suport for newer versions of Firebase SDK, like Firebase SDK 12

